### PR TITLE
Replace .newInstance() with .getDeclaredConstructor().newInstance()

### DIFF
--- a/src/test/java/datawave/webservice/ProtobufSerializationTestBase.java
+++ b/src/test/java/datawave/webservice/ProtobufSerializationTestBase.java
@@ -42,7 +42,7 @@ public class ProtobufSerializationTestBase {
         assertNotNull(fieldValues);
         assertEquals(fieldNames.length, fieldValues.length);
         
-        T original = clazz.newInstance();
+        T original = clazz.getDeclaredConstructor().newInstance();
         for (int i = 0; i < fieldNames.length; ++i)
             field(clazz, fieldNames[i]).set(original, fieldValues[i]);
         


### PR DESCRIPTION
Class.newInstance() is deprecated.

Replace the deprecated calls with the suggested alternative, `.getDeclaredConstructor().newInstance()`

part of https://github.com/NationalSecurityAgency/datawave/issues/2443